### PR TITLE
updated for GNOME 45

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,13 +4,7 @@
   "name": "NoAnnoyance (fork)",
   "gettext-domain": "gnome-shell-extension-noannoyance",
   "settings-schema": "org.gnome.shell.extensions.noannoyance",
-  "shell-version": [
-    "40",
-    "41",
-    "42",
-    "43",
-    "44"
-  ], 
-  "url": "https://github.com/jirkavrba/noannoyance", 
-  "uuid": "noannoyance@vrba.dev"
+  "shell-version": ["45"],
+  "url": "https://github.com/BjoernDaase/noannoyance",
+  "uuid": "noannoyance@daase.net"
 }


### PR DESCRIPTION
GNOME 45 broke a lot of things here. I tried my best to keep things about how they were, but trying to edit `Main.windowAttentionHandler` giver me an error saying it's read-only. So I'm just raising the window instead, and that's enough to avoid the annoying notification.

It will still probably show the notification when a window is ignored, but I haven't tested that since I don't use it.

The settings part is VERY badly ported - currently it looks like this:

![image](https://github.com/jirkavrba/noannoyance/assets/2374520/8d51f7f2-970b-4f48-ad2f-1b10e7735c7b)

Workable, but pretty terrible all around. But might be a good starting point if you want to work on it :).

I've changed the supported version to just 45 [as recommended on GNOME's porting guide](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#shell-version), since e.g.o supports multi-versioning.