### PR TITLE
Add GNOME 46 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NoAnnoyance (fork)
 
-This extension is a fork of the original, that adds support for GNOME 45
+This extension is a fork of the original, that adds support for GNOME 45 and 46
 
 ## About
 Another extension, that removes the 'Window is ready' notification and puts the window into focus.  
@@ -10,6 +10,7 @@ This is a fork of https://github.com/sindex/no-annoyance, so thank you Alex for 
 
 ## Supported GNOME versions
 - 45
+- 46
 
 ## Installation
 1. Run `git clone git@github.com:jirkavrba/noannoyance.git`

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "name": "NoAnnoyance (fork)",
   "gettext-domain": "gnome-shell-extension-noannoyance-fork",
   "settings-schema": "org.gnome.shell.extensions.noannoyance-fork",
-  "shell-version": ["45"],
+  "shell-version": ["45", "46"],
   "url": "https://github.com/jirkavrba/noannoyance",
   "uuid": "noannoyance-fork@vrba.dev"
 }


### PR DESCRIPTION
Hi, I verified that the extension works on GNOME 46 (I'm running Fedora 40). This PR only adds the support to `metadata.json` and to `README`.